### PR TITLE
Add license, gitignore, expand README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore token files and local receipt files
+*.token
+*.receipt
+
+# General backup files
+*~

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # my-first-codex-project
+
 One Click File Request to Dropbox from CSV
+
+## Setup
+
+Clone the repository and navigate into the project directory:
+
+```bash
+git clone <repository-url>
+cd my-first-codex-project
+```
+
+## Installation
+
+This project currently has no external dependencies. If dependencies are added
+later, install them using your package manager of choice. For example, with
+`pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run your scripts or tools as needed. For example:
+
+```bash
+python request_files.py --csv users.csv
+```
+
+Adjust the command above to match your actual entry point and CSV file.


### PR DESCRIPTION
## Summary
- add MIT license
- add a .gitignore for tokens and receipts
- expand README with basic setup, installation, and usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68746f6f063c832e97bde0caa4150a63