### PR TITLE
Add Dropbox file request script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to `.env` and fill in your Dropbox access token
+DROPBOX_ACCESS_TOKEN=your_dropbox_access_token

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # my-first-codex-project
+
 One Click File Request to Dropbox from CSV
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install dropbox
+   ```
+2. Set the environment variable `DROPBOX_ACCESS_TOKEN` with your Dropbox API token. You can create a `.env` file by copying `.env.example`:
+   ```bash
+   cp .env.example .env
+   # edit .env and fill in your token
+   ```
+
+## Usage
+
+Run the script and pass the path to your CSV file:
+
+```bash
+python dropbox_file_request.py requests.csv
+```
+
+The CSV must have `title` and `destination` columns describing the file request title and the destination folder in your Dropbox.

--- a/dropbox_file_request.py
+++ b/dropbox_file_request.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Create Dropbox file requests from a CSV file."""
+
+import csv
+import os
+import sys
+
+try:
+    import dropbox
+except ImportError as e:
+    print("dropbox package is required. Install with 'pip install dropbox'.")
+    raise
+
+ACCESS_TOKEN = os.environ['DROPBOX_ACCESS_TOKEN']
+
+
+def create_file_requests(csv_path: str) -> None:
+    """Create Dropbox file requests defined in a CSV file."""
+    dbx = dropbox.Dropbox(ACCESS_TOKEN)
+
+    with open(csv_path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            title = row.get('title') or row.get('Title')
+            destination = row.get('destination') or row.get('Destination')
+            if not title or not destination:
+                print(f"Skipping incomplete row: {row}")
+                continue
+            res = dbx.file_requests_create(title, destination)
+            print(f"Created file request '{title}': {res.url}")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(f"Usage: {argv[0]} <path_to_csv>")
+        return 1
+    csv_path = argv[1]
+    create_file_requests(csv_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `dropbox_file_request.py` to create Dropbox file requests from CSV data
- load access token from the `DROPBOX_ACCESS_TOKEN` environment variable
- document environment setup in README
- provide `.env.example` with the required variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68746f6dd658832ea70effe47a0e4e53